### PR TITLE
Translation sync

### DIFF
--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -69,10 +69,8 @@ class Discover extends React.Component<IDiscoverProps, IDiscoverState> {
                     translation: this.props.contentManager.GetTranslationName()
                 });
                 this.forward();
-                
             }
         }
-
     };
 
     forward = () => {

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -47,9 +47,6 @@ class Discover extends React.Component<IDiscoverProps, IDiscoverState> {
 
     // life cycle
     ionViewWillEnter() {
-
-        console.log(this.props.contentManager.GetTranslationName());
-
         if (this.props.contentManager.IsTranslatationReady()) {
 
             if (this.state.translation !== this.props.contentManager.GetTranslationName()) {
@@ -59,7 +56,7 @@ class Discover extends React.Component<IDiscoverProps, IDiscoverState> {
                     head: -1
                 });
             }
-            
+
             if (this.state.allStatements.length === 0) {
 
                 this.props.contentManager.ClearFiltersNoRefresh();
@@ -76,7 +73,6 @@ class Discover extends React.Component<IDiscoverProps, IDiscoverState> {
             }
         }
 
-        console.log(this.state.translation);
     };
 
     forward = () => {

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -22,7 +22,8 @@ type IDiscoverProps = {
 type IDiscoverState = {
     allStatements: Array<IStatement>,
     selectedStatements: Array<IStatement>,
-    head: number
+    head: number,
+    translation: string
 }
 
 const SelectRandom = (pool: Array<IStatement>) => {
@@ -39,13 +40,26 @@ class Discover extends React.Component<IDiscoverProps, IDiscoverState> {
         this.state = {
             allStatements: [],
             selectedStatements: [],
-            head: -1
+            head: -1,
+            translation: ""
         };
     }
 
     // life cycle
     ionViewWillEnter() {
+
+        console.log(this.props.contentManager.GetTranslationName());
+
         if (this.props.contentManager.IsTranslatationReady()) {
+
+            if (this.state.translation !== this.props.contentManager.GetTranslationName()) {
+                this.setState({
+                    allStatements: [],
+                    selectedStatements: [],
+                    head: -1
+                });
+            }
+            
             if (this.state.allStatements.length === 0) {
 
                 this.props.contentManager.ClearFiltersNoRefresh();
@@ -54,12 +68,15 @@ class Discover extends React.Component<IDiscoverProps, IDiscoverState> {
                 this.setState({
                     allStatements: this.props.contentManager.GetModel().ComponentModels.map(comp => {
                         return (comp.Model as IStatement);
-                    })
+                    }),
+                    translation: this.props.contentManager.GetTranslationName()
                 });
+                this.forward();
+                
             }
-
-            this.forward();
         }
+
+        console.log(this.state.translation);
     };
 
     forward = () => {


### PR DESCRIPTION
1) Moved forward() method to only trigger when the when allStatements is empty. 
2) Discover page will now reset to new translation if translation is changed on the main page.