### PR TITLE
TODO: fix weird button failure on tab switch

### DIFF
--- a/src/components/ProverbView.tsx
+++ b/src/components/ProverbView.tsx
@@ -21,6 +21,12 @@ type IProps = {
 
 const ProverbView : React.FC<IProps> = (props) => {
 
+  //states (init viewFolder to null)  
+    //Iprops: checks types. 
+    //strongly typed = put a dot 
+    //types can be objects or primitives. 
+    //const numArray: number[] = {1,2,3,4}; or Array<number> or Array<number | string> <---"union"
+
   const [viewFolderModal, setViewFolderModal] = useState<IVerse | null>(null); // null for closed, IFolder for open
   const [folders, setFolders] = useState<Array<IFolder>>([]);
 
@@ -30,6 +36,7 @@ const ProverbView : React.FC<IProps> = (props) => {
   }, [props.context, props.componentModels])
 
   const refreshFolders = () => {
+    console.log('folders refreshed: ' + StorageAssistant.getFolders())
     StorageAssistant.getFolders()
     .then(folders => folders.sort((folder1, folder2) => folder1.order - folder2.order))
     .then(sortedFolders => setFolders(sortedFolders));
@@ -54,7 +61,6 @@ const ProverbView : React.FC<IProps> = (props) => {
             }
         );
     }
-
     props.refreshComponentModels();
   }
 
@@ -81,7 +87,7 @@ const ProverbView : React.FC<IProps> = (props) => {
         });
     }
 
-    // Statement
+    // Statement                                                                  // This is what's important!
     else if (c.Type === "Statement")
     {
         const statementModel = (c.Model as IStatement);

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -6,24 +6,34 @@ import {
     IonPage,
     IonTitle,
     IonContent,
-    IonGrid, IonCol, IonRow, withIonLifeCycle, IonButton, CreateAnimation
+    IonGrid, IonCol, IonRow, withIonLifeCycle, IonButton, CreateAnimation, IonModal, IonButtons, IonList
 } from '@ionic/react';
+import DefaultConfig from "../pages/DefaultDisplayConfig";
 import ContentManager from "../api/ContentManager";
 import {Statement} from "../components/Statement"
-import {IStatement} from "../api/Interfaces";
+import {IStatement,IModel, ISection, ILibraryContext, IVerse} from "../api/Interfaces";
 import update from "immutability-helper";
+import StorageAssistant, { IFolder } from '../api/StorageAssistant';
 import "./Discover.css";
+
 import {chevronBackOutline, chevronForwardOutline} from "ionicons/icons";
+import Indexer from '../api/Indexer';
+import { FolderCheckbox } from '../components/FolderCheckbox';
 
 type IDiscoverProps = {
-    contentManager: ContentManager
+    contentManager: ContentManager,
+    heartAndVanish?: Boolean
 }
 
 type IDiscoverState = {
     allStatements: Array<IStatement>,
     selectedStatements: Array<IStatement>,
     head: number,
-    translation: string
+    model: IModel,
+    context: ILibraryContext,
+    translation: string,
+    viewFolderModal: IVerse | null,
+    folders: Array<IFolder>
 }
 
 const SelectRandom = (pool: Array<IStatement>) => {
@@ -34,16 +44,81 @@ const SelectRandom = (pool: Array<IStatement>) => {
 class Discover extends React.Component<IDiscoverProps, IDiscoverState> {
 
     private proverbCenterRef: React.RefObject<CreateAnimation> = React.createRef();
+    private cm : ContentManager; // short syntax
 
     constructor(props : IDiscoverProps) {
         super(props);
+        this.cm = this.props.contentManager;
+
         this.state = {
             allStatements: [],
             selectedStatements: [],
             head: -1,
-            translation: ""
+            translation: "",
+            model: this.cm.GetModel(), // A blank model
+            viewFolderModal: null,
+            folders: [],
+            context: {
+                Mode: DefaultConfig.typeDisplay,
+                Chapter: (DefaultConfig.chapter as {[key: string]: number;}),
+                Section: (DefaultConfig.section as {[key: string]: ISection;}),
+                BrowseMode: (DefaultConfig.browseMode)
+            },
         };
     }
+   
+    //Used as callback f(x) for the hearting a card.
+    heartHandler = (statementModel : IStatement) => {
+        //this.refreshComponentModels();
+        //this.refreshFolders();
+        
+        console.log("Heart Handler stats: ")
+        //console.log(this.state.selectedStatements)
+        //console.log(this.state.selectedStatements[this.state.head])
+        //console.log(statementModel) //This is out of date / incorrect. 
+        //console.log(statementModel.Saved)
+        if (statementModel.Saved) {
+            console.log("Removing heart");
+            this.props.contentManager.RemoveBookmark(
+                {
+                    Chapter: statementModel.Verse.Chapter,
+                    VerseNumber: statementModel.Verse.VerseNumber
+                }
+            );
+        } else {
+            console.log("adding heart");
+            this.props.contentManager.Bookmark(
+                {
+                    Chapter: statementModel.Verse.Chapter,
+                    VerseNumber: statementModel.Verse.VerseNumber
+                }
+            );
+        }
+        this.refreshComponentModels();
+        this.refreshFolders(); //Added
+      }
+
+    
+    /* A. Verse model for saving verse in folder */
+    openVerseOptions = (verse: IVerse) => {
+        console.log("openVerseOptions > viewFolderModal should now not be null!")
+        this.refreshFolders(); //Refresh folders every time we open the Verse model
+        //this.state.viewFolderModal = verse;
+        this.setState(update(this.state,{
+            viewFolderModal: {$set:verse},
+        }));
+    }
+    //const [folders, setFolders] = useState<Array<IFolder>>([]);
+
+    //A.1 used in f(x) A. openVerseOptions()
+    refreshFolders = () => {
+        console.log("D_folders refreshed: " + StorageAssistant.getFolders())
+        StorageAssistant.getFolders()
+        .then(folders => folders.sort((folder1, folder2) => folder1.order - folder2.order))
+        .then(sortedFolders => update(this.state,{
+            folders: {$set:sortedFolders},
+        }));
+      }
 
     // life cycle
     ionViewWillEnter() {
@@ -110,9 +185,55 @@ class Discover extends React.Component<IDiscoverProps, IDiscoverState> {
         }
     };
 
+    //Pasted from Library.tsx
+    refreshComponentModels = () => {
+        this.setState({model: this.cm.GetModel()});
+    }
+
+    
+
     render() {
+        let pageRef = React.createRef<any>();
         return (
             <>
+            {/* Modal to view popup folders */}
+            <IonModal
+                isOpen={(this.state.viewFolderModal !== null)}
+                swipeToClose={true}
+
+                onDidDismiss={()=>{
+                    this.refreshFolders(); 
+                    this.setState(update(this.state,{viewFolderModal: {$set:null},}))
+                    }}>
+                <IonHeader>
+                    <IonToolbar>
+                        <IonTitle>Folders</IonTitle>
+                        <IonButtons slot="end">
+                            <IonButton onClick={()=>{
+                                this.refreshFolders(); 
+                                this.setState(update(this.state,{viewFolderModal: {$set:null},}))
+                            }}>Close</IonButton>
+                        </IonButtons>
+                    </IonToolbar>
+                </IonHeader>
+                <IonContent fullscreen>
+                    <div id={"parentmodeldiv"}>
+                        <IonList>
+                            {
+                            this.state.folders.map((f, index) => {
+                                const chapter = (this.state.viewFolderModal !== null) ? this.state.viewFolderModal.Chapter : 0;
+                                const verse = (this.state.viewFolderModal !== null) ? this.state.viewFolderModal.VerseNumber : 0;
+                                const verseSignature = Indexer.GetVerseSignature(Indexer.GetVerseID(chapter, verse));
+
+                                return (
+                                <FolderCheckbox key={index} folder={f} verseSignature={verseSignature}></FolderCheckbox>
+                                )
+                            })
+                            }
+                        </IonList>
+                    </div>
+                </IonContent>
+            </IonModal>
                 <IonPage>
                     <IonHeader>
                         <IonToolbar>
@@ -121,6 +242,7 @@ class Discover extends React.Component<IDiscoverProps, IDiscoverState> {
                     </IonHeader>
 
                     <IonContent className={"discover-content"}>
+
                         <IonGrid>
                             <IonRow justify-content-center align-items-center>
                                 <IonCol size={"1"} className={"button-col"}>
@@ -142,8 +264,9 @@ class Discover extends React.Component<IDiscoverProps, IDiscoverState> {
                                                 (this.state.selectedStatements.length > 0)
                                                     ? <Statement
                                                         model={this.state.selectedStatements[this.state.head]}
-                                                        heartCallback={() => {}}
-                                                        openVerseOptions={() => {}}
+                                                        heartCallback={() => {this.heartHandler(this.state.selectedStatements[this.state.head])}}
+                                                        openVerseOptions={() => {this.openVerseOptions(this.state.selectedStatements[this.state.head].Verse)}}
+                                                       
                                                         />
                                                     : <></>
                                             }


### PR DESCRIPTION
There are some issues, and I don't know if they're due to my changes or something else deeper in the code:
1. When I heart something on Discover.tsx, then Library.tsx, then Discover.tsx again, only the second hearting on Discover does not work. The logic within heartHandler() is working, but it looks like the function this.props.contentManager.[RemoveBookmark or Bookmark] has stopped working. 
2. Is the folder modal supposed to be totally empty? It was like that when I pulled from develop, jw.